### PR TITLE
refactor(px2rem): :art: convert px measurements to tailwind classes

### DIFF
--- a/src/css/_custom-styles.css
+++ b/src/css/_custom-styles.css
@@ -41,7 +41,7 @@ p {
 }
 
 p.small {
-  font-size: 16px !important;
+  @apply !text-base;
 }
 
 a {
@@ -57,23 +57,11 @@ a:hover {
 }
 
 .anchor-link {
-  @apply relative invisible block;
-}
-
-@media (min-width: theme("screens.md")) {
-  .anchor-link {
-    top: -10rem;
-  }
+  @apply relative invisible block md:-top-40;
 }
 
 .container {
-  @apply p-6;
-}
-
-@media (min-width: theme("screens.sm")) {
-  .container {
-    @apply px-8 py-12;
-  }
+  @apply p-6 sm:px-8 sm:py-12;
 }
 
 .logo {
@@ -122,19 +110,7 @@ footer {
 }
 
 main {
-  padding-top: 3.75rem;
-}
-
-@media (min-width: theme("screens.md")) {
-  main {
-    padding-top: 4rem;
-  }
-}
-
-@media (min-width: theme("screens.lg")) {
-  main {
-    padding-top: 5rem;
-  }
+  @apply pt-[3.75rem] md:pt-16 lg:pt-20;
 }
 
 /* Banner Styles */
@@ -307,10 +283,10 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .accordion-item > button {
+  @apply text-base;
   color: #52606d;
   display: flex;
   align-items: center;
-  font-size: 16px;
   font-weight: 700;
   padding: 16px 24px;
   justify-content: space-between;
@@ -367,11 +343,10 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 #breadcrumbs {
+  @apply text-xs leading-normal;
   box-shadow: 0 1px 2px 0 rgb(81 81 81 / 33%);
   color: #207127;
-  font-size: 12px;
   padding: 0.25rem 0.5rem;
-  line-height: 1.5;
 }
 
 .card-grid {
@@ -458,18 +433,16 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .card h4 {
+  @apply text-base leading-normal;
   color: #207127;
-  font-size: 16px;
   font-weight: 600;
-  line-height: 1.5;
   padding-bottom: 0.5rem;
 }
 
 .card p {
+  @apply text-base leading-normal;
   color: #222222;
-  font-size: 16px;
   font-weight: 400;
-  line-height: 1.5;
   margin: 0;
 }
 
@@ -529,14 +502,13 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .button {
+  @apply text-base leading-tight;
   background: #207127;
   border: 2px solid #207127;
   border-radius: 2px;
   color: white;
   display: inline-block;
   font-weight: 700;
-  font-size: 16px;
-  line-height: 1.38;
   outline-offset: 2px;
   margin: 1em 15px 15px 0;
   padding: 16px 32px;
@@ -754,18 +726,16 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .card h4 {
+  @apply text-base leading-normal;
   color: #207127;
-  font-size: 16px;
   font-weight: 600;
-  line-height: 1.5;
   padding-bottom: 0.5rem;
 }
 
 .card p {
+  @apply text-base leading-normal;
   color: #222222;
-  font-size: 16px;
   font-weight: 400;
-  line-height: 1.5;
   margin: 0;
 }
 
@@ -832,24 +802,22 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .components form {
-  font-size: 16px;
-  line-height: 1.5;
+  @apply text-base leading-normal;
 }
 
 .components form label {
-  font-size: 14px;
+  @apply text-sm leading-normal;
   margin-bottom: 0.5em;
 }
 
 .components form button:not(.button) {
+  @apply text-base leading-tight;
   background: white;
   border: 2px solid #207127;
   border-radius: 2px;
   color: #207127;
   display: inline-block;
   font-weight: 700;
-  font-size: 16px;
-  line-height: 1.38;
   margin-top: 1em;
   outline-offset: 2px;
   padding: 16px 32px;
@@ -873,9 +841,9 @@ form[data-handle="whyWasThisPageHelpful"] {
 
 .components input,
 .components select {
+  @apply text-sm leading-tight;
   background: white;
   color: #6b7280;
-  font-size: 14px;
   margin-top: 0.75rem;
 }
 
@@ -900,16 +868,9 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .components table {
-  font-size: 15px;
-  line-height: 1.38;
+  @apply text-sm leading-tight md:text-base md:leading-tight;
   margin-top: 1.5em;
   width: 100%;
-}
-
-@media (min-width: 768px) {
-  .components table {
-    font-size: 16px;
-  }
 }
 
 .components table caption {
@@ -938,31 +899,17 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .components h1 {
-  font-size: 30px;
+  @apply text-3xl md:text-4xl;
   font-weight: 700;
-  line-height: 1.2;
   margin-top: 0;
   margin-bottom: 0;
-}
-
-@media (min-width: 768px) {
-  .components h1 {
-    font-size: 36px;
-  }
 }
 
 .components h2 {
-  font-size: 24px;
+  @apply text-xl leading-tight md:text-3xl;
   font-weight: 700;
-  line-height: 1.2;
   margin-top: 0;
   margin-bottom: 0;
-}
-
-@media (min-width: 768px) {
-  .components h2 {
-    font-size: 30px;
-  }
 }
 
 .components-format h2 {
@@ -970,26 +917,19 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .components h3 {
-  font-size: 20px;
+  @apply text-xl md:text-2xl;
   font-weight: 700;
-  line-height: 1.2;
   margin-top: 0;
   margin-bottom: 0;
 }
 
-@media (min-width: 768px) {
-  .components h3 {
-    font-size: 24px;
-  }
-}
 .components-format h3 {
   padding-top: 1.5em;
 }
 
 .components h4 {
-  font-size: 20px;
+  @apply text-xl;
   font-weight: 600;
-  line-height: 1.2;
   margin-top: 0;
   margin-bottom: 0;
 }
@@ -1088,8 +1028,7 @@ form[data-handle="whyWasThisPageHelpful"] {
 .components p,
 .components ol,
 .components ul {
-  font-size: 18px;
-  line-height: 1.5;
+  @apply text-lg;
   margin-top: 0;
   margin-bottom: 0;
 }
@@ -1131,8 +1070,7 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .components figcaption {
-  font-size: 14px;
-  line-height: 1.5;
+  @apply text-sm;
   margin-top: 1rem;
 }
 
@@ -1272,16 +1210,10 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 #components-sidebar label {
+  @apply text-base pt-6 md:pt-[1.125rem];
   display: block;
-  font-size: 16px;
   font-weight: 700;
   padding-top: 24px;
-}
-
-@media (min-width: 768px) {
-  #components-sidebar label {
-    padding-top: 18px;
-  }
 }
 
 #components-sidebar input,
@@ -1371,35 +1303,23 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .content > h1 {
-  font-size: 1.875rem;
+  @apply text-3xl md:text-4xl;
   margin-bottom: 1rem;
-}
-
-@media (min-width: 768px) {
-  .content > h1 {
-    font-size: 2.25rem;
-  }
 }
 
 .content > h2 {
-  font-size: 1.5rem;
+  @apply text-2xl sm:text-3xl;
   margin-bottom: 1rem;
 }
 
-@media (min-width: 640px) {
-  .content > h2 {
-    font-size: 1.875rem;
-  }
-}
-
 .content > p {
-  font-size: 1.25rem;
+  @apply text-xl;
   max-width: 40rem;
   margin-bottom: 2rem;
 }
 
 .content > ul {
-  font-size: 18px;
+  @apply text-lg;
   font-weight: 700;
   line-height: 2;
 }
@@ -1447,12 +1367,11 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .has-submenu > ul.components h4 {
-  font-size: 16px;
-  padding-bottom: 0.5rem !important;
+  @apply text-base !pb-2;
 }
 
 .has-submenu > ul.components p {
-  font-size: 14px;
+  @apply text-sm;
 }
 
 .has-submenu > ul::before {
@@ -1569,24 +1488,18 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 #helpful p {
-  font-size: 14px;
+  @apply text-sm;
 }
 
 #mobile-menu {
   height: 60px;
-}
-
-@media (min-width: 640px) {
-  #mobile-menu {
-    height: 64px;
-  }
+  @apply h-[3.75rem] sm:h-16;
 }
 
 .pagination {
+  @apply text-base;
   display: flex;
   align-items: center;
-  font-size: 16px;
-  line-height: 1.45;
   margin-left: -10px;
   padding: 0 !important;
 }
@@ -1622,7 +1535,7 @@ form[data-handle="whyWasThisPageHelpful"] {
 
 .pagination .next,
 .pagination .prev {
-  font-size: 0;
+  @apply text-[0];
 }
 
 .pagination .next::after,
@@ -1659,6 +1572,7 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .process > li::before {
+  @apply text-sm;
   border: 3px solid #9e9e9e;
   border-radius: 50%;
   content: attr(data-index);
@@ -1666,7 +1580,6 @@ form[data-handle="whyWasThisPageHelpful"] {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  font-size: 15px;
   font-weight: 600;
   margin-top: -4.5px;
   margin-right: 10px;
@@ -1709,16 +1622,7 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .result h3 {
-  font-size: 20px;
-  line-height: 1.4;
-}
-
-@media (min-width: 768px) {
-  .result h3 {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-  }
+  @apply text-xl md:flex md:items-start md:justify-between;
 }
 
 .result h3 a {
@@ -1727,13 +1631,12 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .result h3 span {
+  @apply text-xs leading-4;
   background: #e0e0e0;
   border-radius: 4px;
   display: inline-block;
-  font-size: 12px;
   font-weight: 400;
   flex-shrink: 0;
-  line-height: 1.333333;
   padding: 6px 12px;
   margin-top: 0.5rem;
   width: auto;
@@ -1757,9 +1660,8 @@ form[data-handle="whyWasThisPageHelpful"] {
 }
 
 .result .updated {
+  @apply text-sm leading-normal;
   color: #626262;
-  font-size: 14px;
-  line-height: 1.5;
 }
 
 .result .updated + p {

--- a/src/css/partials/forms.css
+++ b/src/css/partials/forms.css
@@ -31,23 +31,23 @@
 }
 
 label.form-control {
-  font-size: 14px;
+  @apply text-sm;
   text-transform: uppercase;
 }
 
 select.form-control {
+  @apply text-sm;
   border: 1px solid #CFCFCF;
   border-radius: 4px;
   color: #6B7280;
-  font-size: 14px;
   padding: 0.75rem 1rem;
   width: 100%;
 }
 
 input[type="search"].form-control {
+  @apply text-base;
   background: white;
   color: #3b3b3b;
-  font-size: 16px;
   margin: 0;
   padding: 14px;
   width: 100%;

--- a/src/css/partials/navigation.css
+++ b/src/css/partials/navigation.css
@@ -11,12 +11,11 @@
 }
 
 .has-submenu > ul.components h4 {
-  font-size: 16px;
-  padding-bottom: 0.5rem !important;
+  @apply text-base !pb-2;
 }
 
 .has-submenu > ul.components p {
-  font-size: 14px;
+  @apply text-sm;
 }
 
 .has-submenu > ul::before {
@@ -45,12 +44,11 @@
 }
 
 .has-submenu > a {
+  @apply text-sm leading-normal;
   background: transparent;
   display: flex;
   align-items: center;
-  font-size: 14px;
   font-weight: bold;
-  line-height: 21px;
   padding: 19.5px 16px;
   position: relative;
 }
@@ -207,13 +205,7 @@
 }
 
 #main-navigation {
-  padding-left: 63px;
-}
-
-@media(min-width: 1024px) {
-  #main-navigation {
-      padding-left: 1.5rem;
-  }        
+  @apply pl-16 lg:pl-6;
 }
 
 #mobile-navigation > a {
@@ -251,12 +243,11 @@
 }
 
 #mobile-navigation > ul > li > a {
+  @apply text-lg leading-snug;
   background: #207127;
   display: flex;
   justify-content: space-between;
-  font-size: 18px;
   font-weight: 600;
-  line-height: 21px;
   padding: 15.5px 0;
 }
 
@@ -281,7 +272,7 @@ display: block;
 }
 
 #mobile-navigation .has-submenu > ul > li > a {
-  font-size: 14px;
+  @apply text-sm;
   font-weight: bold;
 }
 
@@ -314,7 +305,7 @@ display: block;
 
 #topbar li,
 #topbar p {
-  font-size: 12px;
+  @apply text-xs;
   list-style: none;
 }
 
@@ -334,9 +325,8 @@ display: block;
 }
 
 #translate > a {
+  @apply text-xs leading-normal;
   font-weight: normal;
-  font-size: 12px;
-  line-height: 1.5;
   padding: 12px 8px;
 }
 
@@ -368,6 +358,6 @@ display: block;
 }
 
 #translate > ul > li {
-  font-size: 14px;
+  @apply text-sm;
   margin: 2.5px 0;
 }

--- a/src/css/partials/timeline.css
+++ b/src/css/partials/timeline.css
@@ -30,8 +30,7 @@
 }
 
 .timeline__item {
-  font-size: 16px;
-  font-size: 1rem;
+  @apply text-base;
   padding: 0.625rem 2.5rem 0.625rem 0;
   position: relative;
   width: 50%;
@@ -135,19 +134,18 @@
 }
 
 .timeline__content h2 {
-  font-size: 1.25rem;
+  @apply text-xl;
   font-weight: 900;
   margin: 0 0 0.625rem;
 }
 
 .timeline__content p {
-  font-size: 0.9375rem;
-  line-height: 1.5;
+  @apply text-sm leading-normal;
   margin-bottom: 10px;
 }
 
 .timeline--horizontal {
-  font-size: 0;
+  @apply text-[0];
   padding: 0 3.125rem;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
Goes through the existing CSS and converts all uses of `font-size` and `line-height` to their equivalent css classes in Tailwind and uses the `@apply` directive at the top of the declaration for each.

This may affect some line spacing, but most of that is from the Tailwind update in the first place. If anything text will be more legible at first and we'll want to compress the line spacing in certain areas as needed.