### PR TITLE
🗑️ (news) add portrait conditional

### DIFF
--- a/templates/news/_partials/media-contact.twig
+++ b/templates/news/_partials/media-contact.twig
@@ -8,12 +8,14 @@
   phone: false,
 }|merge(params) %}
 
-{{ include ("news/_partials/portrait.twig", {
-  params: {
-    image: vars.portrait,
-    alt: vars.portrait.altText ? vars.portrait.altText : "Portrait of #{vars.title}, #{vars.name}"
-  }}
-) }}
+{% if vars.portrait %}
+  {{ include ("news/_partials/portrait.twig", {
+    params: {
+      image: vars.portrait,
+      alt: vars.portrait.altText ? vars.portrait.altText : "Portrait of #{vars.title}, #{vars.name}"
+    }}
+  ) }}
+{% endif %}
 
 <ul>
   <a class="font-bold" target="_blank" href="{{ vars.link }}">{{ vars.name }}</a>


### PR DESCRIPTION
Adds a conditional to only include the portrait partial if an image is provided. While this update isn’t 100% necessary as we check inside the include for the portrait value as well, we *are* attempting to pass image alt text, and failing that, alt text we’ve manually generated. It should normally fail quietly, but I decided it’s easiest and least confusing if we don’t pass alt text when we are already not passing a portrait image.