### PR TITLE
🐛 (staff): Update staff search input placeholder

### DIFF
--- a/templates/staff/index.twig
+++ b/templates/staff/index.twig
@@ -4,7 +4,7 @@
 
 {% js at head %}
 var algoliaIndex = '{{ getenv('ENVIRONMENT') }}_staff';
-var searchInputText = "Search for a specific person. E.g., “Libby Schaaf”";
+var searchInputText = "Search for a specific person. E.g., “Sheng Thao”";
 var hitsRootClass = 'card-grid wide-cards mt-12';
 var facetFilters = [];
 


### PR DESCRIPTION
Adjusts to use Sheng Thao as the placeholder instead of Libby Schaaf.